### PR TITLE
feat: fix minor issue with mongo, cleaned up dead code, add generarot…

### DIFF
--- a/cmd/generate.go
+++ b/cmd/generate.go
@@ -11,15 +11,37 @@ import (
 var CreateProjectCommand *cobra.Command
 var ProjectName string
 
+// Flags
+var (
+	flagDryRun  bool
+	flagModule  string
+	flagGitInit bool
+)
+
 func init() {
 	CreateProjectCommand = &cobra.Command{
 		Use:   "create [project-name]",
-		Short: "Creates a new go project",
-		Args:  cobra.ExactArgs(1),
+		Short: "Creates a new Go project with your chosen framework, database, and ORM",
+		Long: `Creates a new Go project by cloning a framework template and generating
+database connection, migration, environment, and optionally Docker files.
+
+Examples:
+  go-sail create my-app
+  go-sail create my-app --module github.com/myuser/my-app
+  go-sail create my-app --dry-run
+  go-sail create my-app --git-init`,
+		Args: cobra.ExactArgs(1),
 		Run: func(cmd *cobra.Command, args []string) {
 			ProjectName = args[0]
 			ctx := cmd.Context()
-			if err := scripts.CreateProject(ctx, ProjectName); err != nil {
+
+			opts := scripts.CreateOptions{
+				DryRun:     flagDryRun,
+				ModulePath: flagModule,
+				GitInit:    flagGitInit,
+			}
+
+			if err := scripts.CreateProject(ctx, ProjectName, opts); err != nil {
 				if err == errors.ErrInterrupt {
 					fmt.Println("Program Exited: interrupt")
 				} else {
@@ -28,4 +50,8 @@ func init() {
 			}
 		},
 	}
+
+	CreateProjectCommand.Flags().BoolVarP(&flagDryRun, "dry-run", "n", false, "Preview what would be generated without creating any files")
+	CreateProjectCommand.Flags().StringVarP(&flagModule, "module", "m", "", "Custom Go module path (default: project name)")
+	CreateProjectCommand.Flags().BoolVar(&flagGitInit, "git-init", false, "Initialize a git repository with an initial commit after scaffolding")
 }

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -1,0 +1,74 @@
+package cmd
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/TejasGhatte/go-sail/internal/initializers"
+	"github.com/spf13/cobra"
+)
+
+var ListCommand = &cobra.Command{
+	Use:   "list",
+	Short: "List all supported frameworks, databases, and ORMs",
+	Long:  "Displays all available frameworks, databases, ORM options, and their valid combinations.",
+	Run: func(cmd *cobra.Command, args []string) {
+		printSupportedOptions()
+	},
+}
+
+func printSupportedOptions() {
+	// Frameworks
+	fmt.Println("Supported Frameworks:")
+	fmt.Println(strings.Repeat("-", 40))
+	frameworks := sortedKeys(initializers.Config.Repositories)
+	for _, f := range frameworks {
+		fmt.Printf("  • %s\n", f)
+	}
+
+	// Databases
+	fmt.Println("\nSupported Databases:")
+	fmt.Println(strings.Repeat("-", 40))
+	databases := sortedKeys(initializers.Config.Databases)
+	for _, db := range databases {
+		cfg := initializers.Config.Databases[db]
+		fmt.Printf("  • %-12s (driver: %s)\n", db, cfg.DriverPkg)
+	}
+
+	// ORMs
+	fmt.Println("\nSupported ORMs:")
+	fmt.Println(strings.Repeat("-", 40))
+	orms := sortedKeys(initializers.Config.ORMs)
+	for _, o := range orms {
+		cfg := initializers.Config.ORMs[o]
+		fmt.Printf("  • %-14s (import: %s)\n", o, cfg.ImportPath)
+	}
+
+	// Valid Combinations
+	fmt.Println("\nValid Database + ORM Combinations:")
+	fmt.Println(strings.Repeat("-", 40))
+	for _, db := range databases {
+		combos, exists := initializers.Config.Combinations[db]
+		if !exists {
+			continue
+		}
+		ormList := []string{}
+		for ormName := range combos {
+			ormList = append(ormList, ormName)
+		}
+		sort.Strings(ormList)
+		fmt.Printf("  %s → %s\n", db, strings.Join(ormList, ", "))
+	}
+	fmt.Println()
+}
+
+// sortedKeys returns sorted keys from any map[string]T using generics-free approach
+func sortedKeys[T any](m map[string]T) []string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return keys
+}

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -1,0 +1,21 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+// Version is set at build time via ldflags:
+//
+//	go build -ldflags "-X github.com/TejasGhatte/go-sail/cmd.Version=v1.0.0"
+var Version = "dev"
+
+var VersionCommand = &cobra.Command{
+	Use:   "version",
+	Short: "Print the version of go-sail",
+	Long:  "Displays the current version of the go-sail CLI tool.",
+	Run: func(cmd *cobra.Command, args []string) {
+		fmt.Printf("go-sail %s\n", Version)
+	},
+}

--- a/config.yml
+++ b/config.yml
@@ -3,6 +3,11 @@ repositories:
   echo: https://github.com/TejasGhatte/echo-basic-template.git
   gin: https://github.com/TejasGhatte/gin-basic-template.git
 
+templateModules:
+  fiber: github.com/TejasGhatte/fiber-base-template
+  echo: github.com/TejasGhatte/echo-basic-template
+  gin: github.com/TejasGhatte/gin-basic-template
+
 databases:
   postgres:
     name: postgres

--- a/internal/helpers/generators.go
+++ b/internal/helpers/generators.go
@@ -108,3 +108,187 @@ func DBMigrate() error {
 
 	return nil
 }
+
+// GenerateEnvFile generates a .env.example file with database credential placeholders.
+func GenerateEnvFile(ctx context.Context, projectDir, database string) error {
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	default:
+	}
+
+	envContent := map[string]string{
+		"postgres": `# Database Configuration
+DB_HOST=localhost
+DB_PORT=5432
+DB_USER=your_username
+DB_PASSWORD=your_password
+DB_NAME=your_database
+DB_SSLMODE=disable
+
+# Application
+APP_PORT=8080
+APP_ENV=development
+`,
+		"mysql": `# Database Configuration
+DB_HOST=localhost
+DB_PORT=3306
+DB_USER=your_username
+DB_PASSWORD=your_password
+DB_NAME=your_database
+
+# Application
+APP_PORT=8080
+APP_ENV=development
+`,
+		"mongodb": `# Database Configuration
+MONGO_URI=mongodb://localhost:27017
+MONGO_DB_NAME=your_database
+
+# Application
+APP_PORT=8080
+APP_ENV=development
+`,
+		"sqlite": `# Database Configuration
+DB_PATH=./data.db
+
+# Application
+APP_PORT=8080
+APP_ENV=development
+`,
+	}
+
+	content, exists := envContent[database]
+	if !exists {
+		content = fmt.Sprintf("# Database: %s\n# Add your database configuration here\n\nAPP_PORT=8080\nAPP_ENV=development\n", database)
+	}
+
+	filename := filepath.Join(projectDir, ".env.example")
+	return os.WriteFile(filename, []byte(content), 0644)
+}
+
+// GenerateDockerfile generates a multi-stage Dockerfile for the Go project.
+func GenerateDockerfile(ctx context.Context, projectDir string) error {
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	default:
+	}
+
+	dockerfile := `# Build stage
+FROM golang:1.22-alpine AS builder
+
+WORKDIR /app
+
+# Install dependencies
+RUN apk add --no-cache git
+
+# Copy dependency files first for better layer caching
+COPY go.mod go.sum ./
+RUN go mod download
+
+# Copy source code
+COPY . .
+
+# Build binary
+RUN CGO_ENABLED=0 GOOS=linux go build -o /app/server .
+
+# Runtime stage
+FROM alpine:3.19
+
+WORKDIR /app
+
+# Install ca-certificates for HTTPS calls
+RUN apk --no-cache add ca-certificates
+
+# Copy binary from builder
+COPY --from=builder /app/server .
+COPY --from=builder /app/.env.example .env
+
+EXPOSE 8080
+
+CMD ["./server"]
+`
+
+	filename := filepath.Join(projectDir, "Dockerfile")
+	return os.WriteFile(filename, []byte(dockerfile), 0644)
+}
+
+// GenerateDockerCompose generates a docker-compose.yml pre-wired with the selected database.
+func GenerateDockerCompose(ctx context.Context, projectDir, database string) error {
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	default:
+	}
+
+	dbService := map[string]string{
+		"postgres": `  db:
+    image: postgres:16-alpine
+    restart: unless-stopped
+    environment:
+      POSTGRES_USER: your_username
+      POSTGRES_PASSWORD: your_password
+      POSTGRES_DB: your_database
+    ports:
+      - "5432:5432"
+    volumes:
+      - pgdata:/var/lib/postgresql/data
+
+volumes:
+  pgdata:
+`,
+		"mysql": `  db:
+    image: mysql:8.0
+    restart: unless-stopped
+    environment:
+      MYSQL_ROOT_PASSWORD: your_root_password
+      MYSQL_DATABASE: your_database
+      MYSQL_USER: your_username
+      MYSQL_PASSWORD: your_password
+    ports:
+      - "3306:3306"
+    volumes:
+      - mysqldata:/var/lib/mysql
+
+volumes:
+  mysqldata:
+`,
+		"mongodb": `  db:
+    image: mongo:7
+    restart: unless-stopped
+    environment:
+      MONGO_INITDB_DATABASE: your_database
+    ports:
+      - "27017:27017"
+    volumes:
+      - mongodata:/data/db
+
+volumes:
+  mongodata:
+`,
+	}
+
+	dbBlock, exists := dbService[database]
+	if !exists {
+		dbBlock = fmt.Sprintf("  # Add your %s service configuration here\n", database)
+	}
+
+	compose := fmt.Sprintf(`version: "3.8"
+
+services:
+  app:
+    build: .
+    restart: unless-stopped
+    ports:
+      - "8080:8080"
+    env_file:
+      - .env
+    depends_on:
+      - db
+
+%s`, dbBlock)
+
+	filename := filepath.Join(projectDir, "docker-compose.yml")
+	return os.WriteFile(filename, []byte(compose), 0644)
+}

--- a/internal/helpers/rename.go
+++ b/internal/helpers/rename.go
@@ -1,0 +1,51 @@
+package helpers
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// RenameModulePath walks a project directory and replaces all occurrences of
+// oldModulePath with newModulePath in .go files and go.mod.
+// This fixes the template's internal imports to match the user's project name.
+func RenameModulePath(projectDir, oldModulePath, newModulePath string) error {
+	return filepath.Walk(projectDir, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+
+		// Skip directories, vendor, and .git
+		if info.IsDir() {
+			base := filepath.Base(path)
+			if base == "vendor" || base == ".git" || base == "node_modules" {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+
+		// Only process .go files and go.mod
+		ext := filepath.Ext(path)
+		base := filepath.Base(path)
+		if ext != ".go" && base != "go.mod" && base != "go.sum" {
+			return nil
+		}
+
+		content, err := os.ReadFile(path)
+		if err != nil {
+			return fmt.Errorf("failed to read %s: %v", path, err)
+		}
+
+		original := string(content)
+		replaced := strings.ReplaceAll(original, oldModulePath, newModulePath)
+
+		if replaced != original {
+			if err := os.WriteFile(path, []byte(replaced), info.Mode()); err != nil {
+				return fmt.Errorf("failed to write %s: %v", path, err)
+			}
+		}
+
+		return nil
+	})
+}

--- a/internal/initializers/load_config.go
+++ b/internal/initializers/load_config.go
@@ -14,12 +14,11 @@ var Config models.Config
 func LoadConfig(filename string) {
 	data, err := os.ReadFile(filename)
 	if err != nil {
-		log.Fatalf("error reading config file: %v", err) // Change this line
+		log.Fatalf("error reading config file: %v", err)
 	}
 
 	err = yaml.Unmarshal(data, &Config)
 	if err != nil {
-		log.Fatalf("error parsing config file: %v", err) // Change this line
+		log.Fatalf("error parsing config file: %v", err)
 	}
-	//fmt.Printf("Loaded Config: %+v\n", Config)
 }

--- a/internal/models/config.go
+++ b/internal/models/config.go
@@ -1,11 +1,12 @@
 package models
 
 type Config struct {
-	Repositories  map[string]string                       `yaml:"repositories"`
-	Databases     map[string]DatabaseConfig               `yaml:"databases"`
-	ORMs          map[string]ORMConfig                    `yaml:"orms"`
-	Combinations  map[string]map[string]CombinationConfig `yaml:"combinations"`
-	MigrationCode map[string]string                       `yaml:"migrationCode"`
+	Repositories    map[string]string                       `yaml:"repositories"`
+	Databases       map[string]DatabaseConfig               `yaml:"databases"`
+	ORMs            map[string]ORMConfig                    `yaml:"orms"`
+	Combinations    map[string]map[string]CombinationConfig `yaml:"combinations"`
+	MigrationCode   map[string]string                       `yaml:"migrationCode"`
+	TemplateModules map[string]string                       `yaml:"templateModules"`
 }
 
 type DatabaseConfig struct {

--- a/internal/models/options.go
+++ b/internal/models/options.go
@@ -5,4 +5,9 @@ type Options struct {
 	Framework   string
 	Database    string
 	ORM         string
+	ModulePath  string // custom go module path (--module flag)
+	DryRun      bool   // preview mode, no files created (--dry-run flag)
+	GitInit     bool   // auto-init git repo after scaffolding (--git-init flag)
+	Docker      bool   // generate Dockerfile + docker-compose.yml
+	EnvFile     bool   // generate .env.example
 }

--- a/internal/prompts/create_prompts.go
+++ b/internal/prompts/create_prompts.go
@@ -2,19 +2,19 @@ package prompts
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/AlecAivazis/survey/v2"
 	"github.com/TejasGhatte/go-sail/internal/errors"
+	"github.com/TejasGhatte/go-sail/internal/initializers"
 )
 
 var frameworks = []string{"fiber", "gin", "echo"}
-var databases = []string{"postgres", "mysql","mongodb", "None"}
-var orms = []string{"gorm", "sqlx","mongo-driver", "None"}
 
 func SelectFramework(ctx context.Context) (string, error) {
 	var framework string
 	prompt := &survey.Select{
-		Message: "🚀 Choose a Go framework:",
+		Message: "Choose a Go framework:",
 		Options: frameworks,
 		Default: "fiber",
 		Help:    "Select the framework you want to use for your project",
@@ -37,9 +37,16 @@ func SelectFramework(ctx context.Context) (string, error) {
 }
 
 func SelectDatabase(ctx context.Context) (string, error) {
+	// Build database list dynamically from config
+	databases := []string{}
+	for name := range initializers.Config.Databases {
+		databases = append(databases, name)
+	}
+	databases = append(databases, "None")
+
 	var database string
 	prompt := &survey.Select{
-		Message: "💾 Choose a database (or None):",
+		Message: "Choose a database (or None):",
 		Options: databases,
 		Default: "None",
 		Help:    "Select the database you want to use, or 'None' if you don't need one",
@@ -63,12 +70,33 @@ func SelectDatabase(ctx context.Context) (string, error) {
 	}
 }
 
-func SelectORM(ctx context.Context) (string, error) {
+// SelectORM shows only ORM options that are valid for the selected database.
+// If only one ORM is available (e.g. mongo-driver for mongodb), it auto-selects it.
+func SelectORM(ctx context.Context, database string) (string, error) {
+	// Get valid ORMs from the combinations config for this database
+	combos, exists := initializers.Config.Combinations[database]
+	if !exists {
+		return "", fmt.Errorf("no ORM combinations found for database %q", database)
+	}
+
+	validORMs := []string{}
+	for ormName := range combos {
+		validORMs = append(validORMs, ormName)
+	}
+
+	// If only one valid ORM, auto-select it
+	if len(validORMs) == 1 {
+		fmt.Printf("Auto-selected ORM: %s (only valid option for %s)\n", validORMs[0], database)
+		return validORMs[0], nil
+	}
+
+	validORMs = append(validORMs, "None")
+
 	var orm string
 	prompt := &survey.Select{
-		Message: "🔗 Choose an ORM (or None):",
-		Options: orms,
-		Default: "None",
+		Message: "Choose an ORM (or None):",
+		Options: validORMs,
+		Default: validORMs[0],
 		Help:    "Select an ORM for database interactions, or 'None' if you don't need one",
 	}
 
@@ -88,5 +116,55 @@ func SelectORM(ctx context.Context) (string, error) {
 			return "", nil
 		}
 		return orm, nil
+	}
+}
+
+// AskDockerSetup asks the user if they want Docker files generated.
+func AskDockerSetup(ctx context.Context) (bool, error) {
+	var wantDocker bool
+	prompt := &survey.Confirm{
+		Message: "Generate Dockerfile and docker-compose.yml?",
+		Default: false,
+		Help:    "Generates a multi-stage Dockerfile and docker-compose.yml pre-wired with your selected database",
+	}
+
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- survey.AskOne(prompt, &wantDocker)
+	}()
+
+	select {
+	case <-ctx.Done():
+		return false, errors.ErrInterrupt
+	case err := <-errCh:
+		if err != nil {
+			return false, err
+		}
+		return wantDocker, nil
+	}
+}
+
+// AskEnvSetup asks the user if they want a .env.example file generated.
+func AskEnvSetup(ctx context.Context) (bool, error) {
+	var wantEnv bool
+	prompt := &survey.Confirm{
+		Message: "Generate .env.example with database credentials template?",
+		Default: true,
+		Help:    "Creates a .env.example file with placeholder database credentials",
+	}
+
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- survey.AskOne(prompt, &wantEnv)
+	}()
+
+	select {
+	case <-ctx.Done():
+		return false, errors.ErrInterrupt
+	case err := <-errCh:
+		if err != nil {
+			return false, err
+		}
+		return wantEnv, nil
 	}
 }

--- a/internal/scripts/create.go
+++ b/internal/scripts/create.go
@@ -15,7 +15,14 @@ import (
 	"github.com/briandowns/spinner"
 )
 
-func CreateProject(ctx context.Context, name string) error {
+// CreateOptions holds CLI flags for the create command.
+type CreateOptions struct {
+	DryRun     bool
+	ModulePath string
+	GitInit    bool
+}
+
+func CreateProject(ctx context.Context, name string, opts CreateOptions) error {
 	framework, err := prompts.SelectFramework(ctx)
 	if err != nil {
 		return err
@@ -28,21 +35,69 @@ func CreateProject(ctx context.Context, name string) error {
 
 	var orm string
 	if database != "" {
-		orm, err = prompts.SelectORM(ctx)
+		orm, err = prompts.SelectORM(ctx, database)
 		if err != nil {
 			return err
 		}
 	}
 
-	fmt.Println("Generating project with the following options:")
-	fmt.Printf("Framework: %s, Database: %s, ORM: %s\n", framework, database, orm)
+	// Ask for Docker setup
+	var wantDocker bool
+	if database != "" {
+		wantDocker, err = prompts.AskDockerSetup(ctx)
+		if err != nil {
+			return err
+		}
+	}
+
+	// Ask for .env.example
+	var wantEnv bool
+	if database != "" {
+		wantEnv, err = prompts.AskEnvSetup(ctx)
+		if err != nil {
+			return err
+		}
+	}
+
+	// Resolve module path
+	modulePath := name
+	if opts.ModulePath != "" {
+		modulePath = opts.ModulePath
+	}
 
 	options := &models.Options{
 		ProjectName: name,
 		Framework:   framework,
 		Database:    database,
 		ORM:         orm,
+		ModulePath:  modulePath,
+		DryRun:      opts.DryRun,
+		GitInit:     opts.GitInit,
+		Docker:      wantDocker,
+		EnvFile:     wantEnv,
 	}
+
+	// Dry run: just print summary and exit
+	if options.DryRun {
+		printDryRun(options)
+		return nil
+	}
+
+	fmt.Println("\nGenerating project with the following options:")
+	fmt.Printf("  Project:    %s\n", name)
+	fmt.Printf("  Module:     %s\n", modulePath)
+	fmt.Printf("  Framework:  %s\n", framework)
+	if database != "" {
+		fmt.Printf("  Database:   %s\n", database)
+		fmt.Printf("  ORM:        %s\n", orm)
+	}
+	if wantDocker {
+		fmt.Printf("  Docker:     yes\n")
+	}
+	if wantEnv {
+		fmt.Printf("  .env file:  yes\n")
+	}
+	fmt.Println()
 
 	// Spinner
 	s := spinner.New(spinner.CharSets[9], 100*time.Millisecond)
@@ -58,6 +113,21 @@ func CreateProject(ctx context.Context, name string) error {
 	if err := runGoModCommands(name); err != nil {
 		return fmt.Errorf("failed to run go mod commands: %v", err)
 	}
+
+	// Git init if requested
+	if options.GitInit {
+		if err := initGitRepo(name); err != nil {
+			return fmt.Errorf("failed to initialize git repo: %v", err)
+		}
+	}
+
+	s.Stop()
+
+	fmt.Println("\nProject created successfully!")
+	fmt.Printf("\n  cd %s\n", name)
+	fmt.Println("  go run main.go")
+	fmt.Println()
+
 	return nil
 }
 
@@ -67,7 +137,16 @@ func PopulateDirectory(ctx context.Context, options *models.Options) error {
 	}
 
 	currentDir, _ := os.Getwd()
-	folder := filepath.Join(currentDir, options.ProjectName, "initializers")
+	projectDir := filepath.Join(currentDir, options.ProjectName)
+	initializersFolder := filepath.Join(projectDir, "initializers")
+
+	// Rename module path in all .go files and go.mod
+	templateModulePath := initializers.Config.TemplateModules[options.Framework]
+	if templateModulePath != "" && options.ModulePath != "" {
+		if err := helpers.RenameModulePath(projectDir, templateModulePath, options.ModulePath); err != nil {
+			return fmt.Errorf("error renaming module path: %v", err)
+		}
+	}
 
 	if options.Database != "" && options.ORM != "" {
 		provider, err := helpers.ProviderFactory(options.Database, options.ORM)
@@ -75,15 +154,67 @@ func PopulateDirectory(ctx context.Context, options *models.Options) error {
 			return fmt.Errorf("error creating database provider: %v", err)
 		}
 
-		if err := helpers.GenerateDatabaseFile(ctx, folder, provider); err != nil {
+		if err := helpers.GenerateDatabaseFile(ctx, initializersFolder, provider); err != nil {
 			return fmt.Errorf("error generating database file: %v", err)
 		}
 
-		if err := helpers.GenerateMigrationFile(ctx, folder, provider); err != nil {
+		if err := helpers.GenerateMigrationFile(ctx, initializersFolder, provider); err != nil {
 			return fmt.Errorf("error generating migration file: %v", err)
 		}
 	}
+
+	// Generate .env.example
+	if options.EnvFile && options.Database != "" {
+		if err := helpers.GenerateEnvFile(ctx, projectDir, options.Database); err != nil {
+			return fmt.Errorf("error generating .env.example: %v", err)
+		}
+	}
+
+	// Generate Docker files
+	if options.Docker {
+		if err := helpers.GenerateDockerfile(ctx, projectDir); err != nil {
+			return fmt.Errorf("error generating Dockerfile: %v", err)
+		}
+		if err := helpers.GenerateDockerCompose(ctx, projectDir, options.Database); err != nil {
+			return fmt.Errorf("error generating docker-compose.yml: %v", err)
+		}
+	}
+
 	return nil
+}
+
+func printDryRun(options *models.Options) {
+	fmt.Println("\n[DRY RUN] The following project would be created:")
+	fmt.Printf("  Project:    %s\n", options.ProjectName)
+	fmt.Printf("  Module:     %s\n", options.ModulePath)
+	fmt.Printf("  Framework:  %s\n", options.Framework)
+	if options.Database != "" {
+		fmt.Printf("  Database:   %s\n", options.Database)
+		fmt.Printf("  ORM:        %s\n", options.ORM)
+	} else {
+		fmt.Println("  Database:   none")
+	}
+	fmt.Printf("  Docker:     %v\n", options.Docker)
+	fmt.Printf("  .env file:  %v\n", options.EnvFile)
+	fmt.Printf("  Git init:   %v\n", options.GitInit)
+
+	fmt.Println("\n  Files that would be generated:")
+	fmt.Printf("    %s/\n", options.ProjectName)
+	fmt.Println("    ├── main.go")
+	fmt.Println("    ├── go.mod")
+	if options.Database != "" && options.ORM != "" {
+		fmt.Println("    ├── initializers/")
+		fmt.Println("    │   ├── database.go")
+		fmt.Println("    │   └── migrations.go")
+	}
+	if options.EnvFile {
+		fmt.Println("    ├── .env.example")
+	}
+	if options.Docker {
+		fmt.Println("    ├── Dockerfile")
+		fmt.Println("    └── docker-compose.yml")
+	}
+	fmt.Println("\n  No files were created.")
 }
 
 func runGoModCommands(projectName string) error {
@@ -126,6 +257,30 @@ func runGoImports(projectDir string) error {
 			return nil
 		}
 		return fmt.Errorf("goimports command failed for directory %s: %v", projectDir, err)
+	}
+
+	return nil
+}
+
+func initGitRepo(projectName string) error {
+	currentDir, _ := os.Getwd()
+	projectDir := filepath.Join(currentDir, projectName)
+
+	commands := [][]string{
+		{"git", "init"},
+		{"git", "add", "."},
+		{"git", "commit", "-m", "Initial commit from go-sail"},
+	}
+
+	for _, cmdArgs := range commands {
+		cmd := exec.Command(cmdArgs[0], cmdArgs[1:]...)
+		cmd.Dir = projectDir
+		cmd.Stdout = os.Stdout
+		cmd.Stderr = os.Stderr
+
+		if err := cmd.Run(); err != nil {
+			return fmt.Errorf("%v failed: %v", cmdArgs, err)
+		}
 	}
 
 	return nil

--- a/main.go
+++ b/main.go
@@ -16,7 +16,10 @@ import (
 var rootCmd = &cobra.Command{
 	Use:   "go-sail",
 	Short: "A CLI for generating project templates for Go backend frameworks",
-	Long:  `go-sail is a CLI tool that generates project templates for Go backend frameworks like Fiber, Echo, and Gin, with pre-configured logging and caching, helping developers quickly set up and initialize projects. Users can choose their own database and ORM configurations, and go-sail generates the necessary files for the project.`,
+	Long: `go-sail is a CLI tool that generates project templates for Go backend
+frameworks like Fiber, Echo, and Gin, with pre-configured logging, caching,
+database, and ORM setups. It supports Docker and .env generation, module
+path renaming, and more.`,
 }
 
 func main() {
@@ -35,13 +38,17 @@ func main() {
 	}()
 
 	initializers.LoadConfig("config.yml")
+
 	rootCmd.AddCommand(cmd.CreateProjectCommand)
+	rootCmd.AddCommand(cmd.VersionCommand)
+	rootCmd.AddCommand(cmd.ListCommand)
 
 	if err := rootCmd.ExecuteContext(ctx); err != nil {
 		fmt.Println(err)
 		os.Exit(1)
 	}
 }
+
 func cleanup(projectName string) {
 	fmt.Println("\nReceived interrupt signal, exiting...")
 	if projectName != "" {


### PR DESCRIPTION
Bug Fixes
MongoDB fixed — ORM prompt now filters by database, auto-selects mongo-driver for MongoDB
Module path rename — Templates no longer keep their original import paths; all .go files and go.mod are rewritten to match the user's project name
Dead code cleanup in load_config.go
New Commands
go-sail version — prints version (injectable via ldflags at build time)
go-sail list — prints all supported frameworks, databases, ORMs, and valid combinations
New Flags on create
--dry-run / -n — preview the file tree without creating anything
--module / -m — custom Go module path
--git-init — auto-initializes a git repo with an initial commit
New Generators
.env.example — database-specific credential placeholders
Dockerfile — multi-stage build
docker-compose.yml — pre-wired with the selected database service